### PR TITLE
Rest backend: pass the parameters as query params for GET requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "science", "visualization"]
 anyhow = "1.0.34"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"
+serde_qs = "0.8.4"
 thiserror = "1.0.22"
 ureq = { version = "1.5.2", default-features=false, features=["tls", "json"] }
 


### PR DESCRIPTION
This fixes GET requests failing when there is a reverse proxy in front
of MLFlow intance. See https://github.com/Finnerale/mlflow-rs/issues/3
for details.